### PR TITLE
Temporary fix for particle effects.

### DIFF
--- a/VehicleEffects/GameExtensions/CustomMovementParticleEffect.cs
+++ b/VehicleEffects/GameExtensions/CustomMovementParticleEffect.cs
@@ -100,8 +100,11 @@ namespace VehicleEffects.GameExtensions
         protected override void CreateEffect()
         {
             // Overridden to make sure the ParticleSystemOverride works correctly
-            base.CreateEffect();
-            if(this.m_effectObject == null)
+            bool effectObjectWasNull = this.m_effectObject == null;
+            //base.CreateEffect();//null pointer exception, seems not to be needed for effect initialization
+           
+            //if(this.m_effectObject == null)//always false after base.CreateEffect()
+            if (effectObjectWasNull)
             {
                 this.m_effectObject = gameObject;
                 this.m_effectComponent = gameObject.GetComponent<ParticleEffect>();


### PR DESCRIPTION
I commented out base.CreateEffect() because of a null pointer exception leading to partial a effect update. Effects still seem to get initialized correctly. (Though the steam effect doesn't look like in 1.5, with or without the call.)